### PR TITLE
Remove time intersection from pairing process

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,8 +78,8 @@ src = ["src"]
 target-version = "py310"
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["ALL"]
-unfixable = []
+lint.fixable = ["ALL"]
+lint.unfixable = []
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/ocsge_pv/delete_data.py
+++ b/src/ocsge_pv/delete_data.py
@@ -259,51 +259,54 @@ def delete_declarations(db_info: dict, declarations: set) -> None:
     logger.info("Deleting declarations and associated pairs")
     deleted_declarations_count = 0
     deleted_pairs_count = 0
-    with psycopg.connect(db_info["_pg_string"]) as conn:
-        try:
-            cur = conn.cursor()
-            with conn.transaction():
-                cur.execute(
-                    sql.SQL(
-                        "DELETE FROM {table} WHERE declaration_id IN ({id_list})"
-                    ).format(
-                        table=sql.Identifier(
-                            db_info["schema"],
-                            db_info["tables"]["links"],
+    if not declarations:
+        logger.info("No declaration to delete.")
+    else:
+        with psycopg.connect(db_info["_pg_string"]) as conn:
+            try:
+                cur = conn.cursor()
+                with conn.transaction():
+                    cur.execute(
+                        sql.SQL(
+                            "DELETE FROM {table} WHERE declaration_id IN ({id_list})"
+                        ).format(
+                            table=sql.Identifier(
+                                db_info["schema"],
+                                db_info["tables"]["links"],
+                            ),
+                            id_list=sql.SQL(", ").join(
+                                sql.Placeholder() * len(declarations)
+                            ),
                         ),
-                        id_list=sql.SQL(", ").join(
-                            sql.Placeholder() * len(declarations)
-                        ),
-                    ),
-                    tuple(declarations),
-                )
-                message = cur.statusmessage
-                count_match = re.match(r"DELETE +([0-9]+)", message)
-                count_str = count_match.group(1)
-                deleted_pairs_count = int(count_str)
+                        tuple(declarations),
+                    )
+                    message = cur.statusmessage
+                    count_match = re.match(r"DELETE +([0-9]+)", message)
+                    count_str = count_match.group(1)
+                    deleted_pairs_count = int(count_str)
 
-                cur.execute(
-                    sql.SQL(
-                        "DELETE FROM {table} WHERE id_dossier IN ({id_list})"
-                    ).format(
-                        table=sql.Identifier(
-                            db_info["schema"],
-                            db_info["tables"]["declarations"],
+                    cur.execute(
+                        sql.SQL(
+                            "DELETE FROM {table} WHERE id_dossier IN ({id_list})"
+                        ).format(
+                            table=sql.Identifier(
+                                db_info["schema"],
+                                db_info["tables"]["declarations"],
+                            ),
+                            id_list=sql.SQL(", ").join(
+                                sql.Placeholder() * len(declarations)
+                            ),
                         ),
-                        id_list=sql.SQL(", ").join(
-                            sql.Placeholder() * len(declarations)
-                        ),
-                    ),
-                    tuple(declarations),
-                )
-                message = cur.statusmessage
-                count_match = re.match(r"DELETE +([0-9]+)", message)
-                count_str = count_match.group(1)
-                deleted_declarations_count = int(count_str)
-        except Exception as exc:
-            logger.error(traceback.format_exc())
-            conn.rollback()
-            raise exc
+                        tuple(declarations),
+                    )
+                    message = cur.statusmessage
+                    count_match = re.match(r"DELETE +([0-9]+)", message)
+                    count_str = count_match.group(1)
+                    deleted_declarations_count = int(count_str)
+            except Exception as exc:
+                logger.error(traceback.format_exc())
+                conn.rollback()
+                raise exc
     logger.info(
         f"{deleted_declarations_count} declarations and {deleted_pairs_count} pairs deleted."
     )
@@ -322,45 +325,54 @@ def delete_detections(db_info: dict, detections: set) -> None:
     logger.info("Deleting detections and associated pairs")
     deleted_detections_count = 0
     deleted_pairs_count = 0
-    with psycopg.connect(db_info["_pg_string"]) as conn:
-        try:
-            cur = conn.cursor()
-            with conn.transaction():
-                cur.execute(
-                    sql.SQL(
-                        "DELETE FROM {table} WHERE detection_id IN ({id_list})"
-                    ).format(
-                        table=sql.Identifier(
-                            db_info["schema"],
-                            db_info["tables"]["links"],
+    if not detections:
+        logger.info("No detection to delete.")
+    else:
+        with psycopg.connect(db_info["_pg_string"]) as conn:
+            try:
+                cur = conn.cursor()
+                with conn.transaction():
+                    cur.execute(
+                        sql.SQL(
+                            "DELETE FROM {table} WHERE detection_id IN ({id_list})"
+                        ).format(
+                            table=sql.Identifier(
+                                db_info["schema"],
+                                db_info["tables"]["links"],
+                            ),
+                            id_list=sql.SQL(", ").join(
+                                sql.Placeholder() * len(detections)
+                            ),
                         ),
-                        id_list=sql.SQL(", ").join(sql.Placeholder() * len(detections)),
-                    ),
-                    tuple(detections),
-                )
-                message = cur.statusmessage
-                count_match = re.match(r"DELETE +([0-9]+)", message)
-                count_str = count_match.group(1)
-                deleted_pairs_count = int(count_str)
+                        tuple(detections),
+                    )
+                    message = cur.statusmessage
+                    count_match = re.match(r"DELETE +([0-9]+)", message)
+                    count_str = count_match.group(1)
+                    deleted_pairs_count = int(count_str)
 
-                cur.execute(
-                    sql.SQL("DELETE FROM {table} WHERE id_v2 IN ({id_list})").format(
-                        table=sql.Identifier(
-                            db_info["schema"],
-                            db_info["tables"]["detections"],
+                    cur.execute(
+                        sql.SQL(
+                            "DELETE FROM {table} WHERE id_v2 IN ({id_list})"
+                        ).format(
+                            table=sql.Identifier(
+                                db_info["schema"],
+                                db_info["tables"]["detections"],
+                            ),
+                            id_list=sql.SQL(", ").join(
+                                sql.Placeholder() * len(detections)
+                            ),
                         ),
-                        id_list=sql.SQL(", ").join(sql.Placeholder() * len(detections)),
-                    ),
-                    tuple(detections),
-                )
-                message = cur.statusmessage
-                count_match = re.match(r"DELETE +([0-9]+)", message)
-                count_str = count_match.group(1)
-                deleted_detections_count = int(count_str)
-        except Exception as exc:
-            logger.error(traceback.format_exc())
-            conn.rollback()
-            raise exc
+                        tuple(detections),
+                    )
+                    message = cur.statusmessage
+                    count_match = re.match(r"DELETE +([0-9]+)", message)
+                    count_str = count_match.group(1)
+                    deleted_detections_count = int(count_str)
+            except Exception as exc:
+                logger.error(traceback.format_exc())
+                conn.rollback()
+                raise exc
     logger.info(
         f"{deleted_detections_count} detections and {deleted_pairs_count} pairs deleted."
     )
@@ -378,33 +390,36 @@ def delete_pairs(db_info: dict, pairs: list) -> None:
     """
     logger.info("Deleting explicit pairs")
     deleted_pairs_count = 0
-    with psycopg.connect(db_info["_pg_string"]) as conn:
-        try:
-            cur = conn.cursor()
-            with conn.transaction():
-                for item in pairs:
-                    cur.execute(
-                        sql.SQL(
-                            "DELETE FROM {table} WHERE declaration_id=%s AND detection_id=%s"
-                        ).format(
-                            table=sql.Identifier(
-                                db_info["schema"],
-                                db_info["tables"]["links"],
-                            )
-                        ),
-                        (
-                            item["declaration"],
-                            item["detection"],
-                        ),
-                    )
-                    message = cur.statusmessage
-                    count_match = re.match(r"DELETE +([0-9]+)", message)
-                    count_str = count_match.group(1)
-                    deleted_pairs_count += int(count_str)
-        except Exception as exc:
-            logger.error(traceback.format_exc())
-            conn.rollback()
-            raise exc
+    if not pairs:
+        logger.info("No pair to delete.")
+    else:
+        with psycopg.connect(db_info["_pg_string"]) as conn:
+            try:
+                cur = conn.cursor()
+                with conn.transaction():
+                    for item in pairs:
+                        cur.execute(
+                            sql.SQL(
+                                "DELETE FROM {table} WHERE declaration_id=%s AND detection_id=%s"
+                            ).format(
+                                table=sql.Identifier(
+                                    db_info["schema"],
+                                    db_info["tables"]["links"],
+                                )
+                            ),
+                            (
+                                item["declaration"],
+                                item["detection"],
+                            ),
+                        )
+                        message = cur.statusmessage
+                        count_match = re.match(r"DELETE +([0-9]+)", message)
+                        count_str = count_match.group(1)
+                        deleted_pairs_count += int(count_str)
+            except Exception as exc:
+                logger.error(traceback.format_exc())
+                conn.rollback()
+                raise exc
     logger.info(f"{deleted_pairs_count} pairs deleted.")
 
 

--- a/src/ocsge_pv/pair_from_sources.py
+++ b/src/ocsge_pv/pair_from_sources.py
@@ -212,7 +212,7 @@ def load_configuration(path: Path) -> dict:
 def check_declared_parcels(data_layer: ogr.Layer) -> set[int]:
     """Check for duplicate parcels in declarations
 
-    When multiple declarations, for the same installation date,
+    When multiple declarations, for the same installation year,
     have at least one common selected parcel, only the most recent
     declaration is deemed correct. The rest is discarded, and thus
     marked for deletion.
@@ -225,6 +225,7 @@ def check_declared_parcels(data_layer: ogr.Layer) -> set[int]:
     """
     # Create the set of id to delete
     deletion_set = set()
+    deletion_cause_dict = {}
     # Create a parcels dict with a more useful structure
     parcels_dict = {}
     for feature in data_layer:
@@ -232,6 +233,10 @@ def check_declared_parcels(data_layer: ogr.Layer) -> set[int]:
         parcels_string = feature.GetField("num_parcelles")
         if parcels_string is None or parcels_string == "":
             deletion_set.add(feature_id)
+            if feature_id not in deletion_cause_dict:
+                deletion_cause_dict[feature_id] = set()
+            cause = "no associated cadastral parcel"
+            deletion_cause_dict[feature_id].add(cause)
         else:
             parcels_list = parcels_string.split(";")
             feature_year = feature.GetFieldAsDateTime("date_insta")[0]
@@ -260,6 +265,16 @@ def check_declared_parcels(data_layer: ogr.Layer) -> set[int]:
                 detection_id = parcels_dict[idu][year][creation_iso]
                 if creation_object < last_creation:
                     deletion_set.add(detection_id)
+                    if detection_id not in deletion_cause_dict:
+                        deletion_cause_dict[detection_id] = set()
+                    cause = (
+                        "geometry overlaps with a more recent dossier "
+                        + f"with the same effective installation year {year})"
+                    )
+                    deletion_cause_dict[detection_id].add(cause)
+    for fid in list(deletion_set):
+        message = f"Declaration dossier {fid} will be deleted. (Causes: {str(deletion_cause_dict[fid])})"
+        logger.info(message)
     return deletion_set
 
 
@@ -299,6 +314,8 @@ def match_dec_to_det(
         old_linked_dec_set = set()
         det_fid = det_feature.GetFID()
         det_geom = det_feature.GetGeometryRef().Clone()
+        if det_geom is None or det_geom.IsEmpty():
+            raise ValueError(f"Detection '{det_fid}' has a empty or null geometry.")
         link_layer.SetAttributeFilter(f"detection_id = {det_fid}")
         for link_feature in link_layer:
             dec_fid = link_feature.GetField("declaration_id")
@@ -311,40 +328,30 @@ def match_dec_to_det(
                 result["del"].add(link_tuple)
             else:
                 creation_iso = dec_feature.GetField("creation").replace("/", "-")
-                installation_iso = dec_feature.GetField("date_insta").replace("/", "-")
                 linked_dec_dict[dec_fid] = {
                     "creation": datetime.fromisoformat(creation_iso),
-                    "installation": datetime.fromisoformat(installation_iso),
                 }
             old_linked_dec_set.add(dec_fid)
         for dec_feature in dec_layer:
-            dec_year = dec_feature.GetFieldAsDateTime("date_insta")[0]
             dec_geom = dec_feature.GetGeometryRef().Clone()
-            if dec_geom is not None and det_feature.GetField("millesime") >= dec_year:
+            if dec_geom is not None and not dec_geom.IsEmpty():
                 if need_swap:
                     dec_geom.SwapXY()
                 if transform is not None:
                     dec_geom.Transform(transform)
                 if det_geom.Intersects(dec_geom):
                     creation_iso = dec_feature.GetField("creation").replace("/", "-")
-                    installation_iso = dec_feature.GetField("date_insta").replace(
-                        "/", "-"
-                    )
                     linked_dec_dict[dec_feature.GetFID()] = {
                         "creation": datetime.fromisoformat(creation_iso),
-                        "installation": datetime.fromisoformat(installation_iso),
                     }
         latest_fid = None
         for dec_fid in list(linked_dec_dict):
             dec_feature = dec_layer.GetFeature(dec_fid)
             creation_iso = dec_feature.GetField("creation").replace("/", "-")
             creation_dt = datetime.fromisoformat(creation_iso)
-            installation_iso = dec_feature.GetField("date_insta").replace("/", "-")
-            installation_dt = datetime.fromisoformat(installation_iso)
             if linked_dec_dict[dec_fid] is None:
                 linked_dec_dict[dec_fid] = {
                     "creation": creation_dt,
-                    "installation": installation_dt,
                 }
             if (
                 latest_fid is None

--- a/src/ocsge_pv/pair_from_sources.py
+++ b/src/ocsge_pv/pair_from_sources.py
@@ -235,7 +235,7 @@ def check_declared_parcels(data_layer: ogr.Layer) -> set[int]:
             deletion_set.add(feature_id)
             if feature_id not in deletion_cause_dict:
                 deletion_cause_dict[feature_id] = set()
-            cause = "no associated cadastral parcel"
+            cause = "No associated cadastral parcel"
             deletion_cause_dict[feature_id].add(cause)
         else:
             parcels_list = parcels_string.split(";")
@@ -268,13 +268,15 @@ def check_declared_parcels(data_layer: ogr.Layer) -> set[int]:
                     if detection_id not in deletion_cause_dict:
                         deletion_cause_dict[detection_id] = set()
                     cause = (
-                        "geometry overlaps with a more recent dossier "
+                        "Geometry overlaps with a more recent dossier "
                         + f"with the same effective installation year {year})"
                     )
                     deletion_cause_dict[detection_id].add(cause)
-    for fid in list(deletion_set):
-        message = f"Declaration dossier {fid} will be deleted. (Causes: {str(deletion_cause_dict[fid])})"
-        logger.info(message)
+    del_list = list(deletion_set)
+    logger.warning(f"Declarations deletion list = {del_list} (Count: {len(del_list)})")
+    for fid in del_list:
+        message = f"Declaration dossier {fid} will be deleted. (Cause·s: {str(deletion_cause_dict[fid])})"
+        logger.warning(message)
     return deletion_set
 
 
@@ -309,6 +311,9 @@ def match_dec_to_det(
             }
     """
     result = {"new": set(), "del": set()}
+    del_cause_dict = {}
+    ignored_old_links_count = 0
+    ignored_new_links_count = 0
     for det_feature in det_layer:
         linked_dec_dict = {}
         old_linked_dec_set = set()
@@ -316,22 +321,25 @@ def match_dec_to_det(
         det_geom = det_feature.GetGeometryRef().Clone()
         if det_geom is None or det_geom.IsEmpty():
             raise ValueError(f"Detection '{det_fid}' has a empty or null geometry.")
+        # Check for existing links with this detection
         link_layer.SetAttributeFilter(f"detection_id = {det_fid}")
         for link_feature in link_layer:
             dec_fid = link_feature.GetField("declaration_id")
             dec_feature = dec_layer.GetFeature(dec_fid)
             if dec_feature is None:
-                logger.warning(
-                    f"Link between detection {det_fid} and missing declaration {dec_fid} will be deleted."
-                )
                 link_tuple = (dec_fid, det_fid)
                 result["del"].add(link_tuple)
+                if str(link_tuple) not in del_cause_dict:
+                    del_cause_dict[str(link_tuple)] = set()
+                cause = f"Dossier {dec_fid} not found"
+                del_cause_dict[str(link_tuple)].add(cause)
             else:
                 creation_iso = dec_feature.GetField("creation").replace("/", "-")
                 linked_dec_dict[dec_fid] = {
                     "creation": datetime.fromisoformat(creation_iso),
                 }
             old_linked_dec_set.add(dec_fid)
+        # Pair this detection with intersecting declarations
         for dec_feature in dec_layer:
             dec_geom = dec_feature.GetGeometryRef().Clone()
             if dec_geom is not None and not dec_geom.IsEmpty():
@@ -344,6 +352,7 @@ def match_dec_to_det(
                     linked_dec_dict[dec_feature.GetFID()] = {
                         "creation": datetime.fromisoformat(creation_iso),
                     }
+        # Check for duplicates, and find which one will be kept
         latest_fid = None
         for dec_fid in list(linked_dec_dict):
             dec_feature = dec_layer.GetFeature(dec_fid)
@@ -358,14 +367,39 @@ def match_dec_to_det(
                 or linked_dec_dict[latest_fid]["creation"] < creation_dt
             ):
                 latest_fid = dec_fid
+        # Decide if found link will be created, deleted, or ignored
         for dec_fid in list(linked_dec_dict):
             # (declaration_fid, detection_fid) tuple
             link_tuple = (dec_fid, det_fid)
-            if dec_fid != latest_fid:
+            if dec_fid != latest_fid and dec_fid in old_linked_dec_set:
+                # Duplicate existing link: mark for deletion
                 result["del"].add(link_tuple)
-            elif dec_fid not in old_linked_dec_set:
+                if str(link_tuple) not in del_cause_dict:
+                    del_cause_dict[str(link_tuple)] = set()
+                cause = f"Duplicate link for detection {det_fid}"
+                del_cause_dict[str(link_tuple)].add(cause)
+            elif dec_fid == latest_fid and dec_fid not in old_linked_dec_set:
+                # New link: mark for creation
                 result["new"].add(link_tuple)
+            elif dec_fid != latest_fid and dec_fid not in old_linked_dec_set:
+                # Duplicate new link: ignored
+                ignored_new_links_count += 1
+            elif dec_fid == latest_fid and dec_fid in old_linked_dec_set:
+                # Still valid existing link: ignored
+                ignored_old_links_count += 1
         link_layer.SetAttributeFilter(None)
+    del_list = list(result["del"])
+    logger.warning(f"Links deletion list: {del_list} (Count: {len(del_list)})")
+    logger.debug(f"Count of new links to add: {len(result['new'])}")
+    logger.debug(f"Count of ignored new links: {ignored_new_links_count}")
+    logger.debug(f"Count of kept old links: {ignored_old_links_count}")
+    for link_tuple in del_list:
+        message = (
+            f"Link between declaration {link_tuple[0]} "
+            + f"and detection {link_tuple[1]} will be deleted "
+            + f"(Cause·s: {del_cause_dict[str(link_tuple)]})"
+        )
+        logger.warning(message)
     return result
 
 


### PR DESCRIPTION
## Changelog   
### [Changed]
* `pair_from_sources`: the pairing function now matches declarations to detections only according to spatial intersection. The date comparison actually contradicted the goal to describe soil occupation at the time of the detection.
* `pair_from_sources`: database objects marked for deletion are now logged alongside their deletion reason.
* `pair_from_sources`: some pairing statistics other than deletions are now logged as debug entries

### [Fixed]
* `pyproject.toml`: changed ruff configuration keys to follow a deprecation warning
* `delete_data`: If the input id list is empty, instead of sending an invalid SQL request, deletion functions now exit before attempting anything
